### PR TITLE
Moved the cap for max body size and parameter count

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,24 @@ const express = require('express'),
   config = require('./config'),
   routes = require('./app/routes'),
   orm = require('./app/orm'),
-  errors = require('./app/middlewares/errors');
+  errors = require('./app/middlewares/errors'),
+  DEFAULT_BODY_SIZE_LIMIT = 1024 * 1024 * 10,
+  DEFAULT_PARAMETER_LIMIT = 10000;
+
+const jsonBodyParser = () => {
+  return bodyParser.json({
+    parameterLimit: config.common.api.parameterLimit || DEFAULT_PARAMETER_LIMIT,
+    limit: config.common.api.bodySizeLimit || DEFAULT_BODY_SIZE_LIMIT
+  });
+};
+
+const urlEncodedBodyParser = () => {
+  return bodyParser.urlencoded({
+    extended: true,
+    parameterLimit: config.common.api.parameterLimit || DEFAULT_PARAMETER_LIMIT,
+    limit: config.common.api.bodySizeLimit || DEFAULT_BODY_SIZE_LIMIT
+  });
+};
 
 const init = () => {
   const app = express();
@@ -16,15 +33,8 @@ const init = () => {
   app.use('/docs', express.static(path.join(__dirname, 'docs')));
 
   // Client must send "Content-Type: application/json" header
-  app.use(bodyParser.json({
-    parameterLimit: 10000,
-    limit: 1024 * 1024 * 10
-  }));
-  app.use(bodyParser.urlencoded({
-    extended: true,
-    parameterLimit: 10000,
-    limit: 1024 * 1024 * 10
-  }));
+  app.use(jsonBodyParser());
+  app.use(urlEncodedBodyParser());
 
   if (config.environment !== 'testing') {
     morgan.token('req-params', (req) => req.params);

--- a/app.js
+++ b/app.js
@@ -16,8 +16,15 @@ const init = () => {
   app.use('/docs', express.static(path.join(__dirname, 'docs')));
 
   // Client must send "Content-Type: application/json" header
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(bodyParser.json({
+    parameterLimit: 10000,
+    limit: 1024 * 1024 * 10
+  }));
+  app.use(bodyParser.urlencoded({
+    extended: true,
+    parameterLimit: 10000,
+    limit: 1024 * 1024 * 10
+  }));
 
   if (config.environment !== 'testing') {
     morgan.token('req-params', (req) => req.params);

--- a/config/development.js
+++ b/config/development.js
@@ -9,6 +9,10 @@ exports.config = {
       username: process.env.NODE_API_DB_USERNAME,
       password: process.env.NODE_API_DB_PASSWORD
     },
+    api: {
+      bodySizeLimit: process.env.API_BODY_SIZE_LIMIT,
+      parameterLimit: process.env.API_PARAMETER_LIMIT
+    },
     session: {
       header_name: 'authorization',
       secret: process.env.NODE_API_SESSION_SECRET

--- a/config/production.js
+++ b/config/production.js
@@ -10,6 +10,10 @@ exports.config = {
       username: process.env.NODE_API_DB_USERNAME,
       password: process.env.NODE_API_DB_PASSWORD
     },
+    api: {
+      bodySizeLimit: process.env.API_BODY_SIZE_LIMIT,
+      parameterLimit: process.env.API_PARAMETER_LIMIT
+    },
     session: {
       header_name: 'authorization',
       secret: process.env.NODE_API_SESSION_SECRET

--- a/config/staging.js
+++ b/config/staging.js
@@ -9,6 +9,10 @@ exports.config = {
       username: process.env.NODE_API_DB_USERNAME,
       password: process.env.NODE_API_DB_PASSWORD
     },
+    api: {
+      bodySizeLimit: process.env.API_BODY_SIZE_LIMIT,
+      parameterLimit: process.env.API_PARAMETER_LIMIT
+    },
     session: {
       header_name: 'authorization',
       secret: process.env.NODE_API_SESSION_SECRET

--- a/config/testing.js
+++ b/config/testing.js
@@ -9,6 +9,10 @@ exports.config = {
       username: process.env.NODE_API_DB_USERNAME,
       password: process.env.NODE_API_DB_PASSWORD
     },
+    api: {
+      bodySizeLimit: process.env.API_BODY_SIZE_LIMIT,
+      parameterLimit: process.env.API_PARAMETER_LIMIT
+    },
     session: {
       header_name: 'authorization',
       secret: process.env.NODE_API_SESSION_SECRET


### PR DESCRIPTION
## Summary
Moved the cap for max body size and parameter count in the JSON Parser used in the bootstrap.

## Reason
We were getting the following error in production:
```
PayloadTooLargeError: too many parameters
1
at queryparse (/var/app/current/node_modules/body-parser/lib/types/urlencoded.js line 260 col 13)
throw createError(413, 'too many parameters')
2
at parse (/var/app/current/node_modules/body-parser/lib/types/urlencoded.js line 75 col 9)
? queryparse(body)
3
at <unknown> (/var/app/current/node_modules/body-parser/lib/read.js line 116 col 18)
req.body = parse(str)
4
at invokeCallback (/var/app/current/node_modules/raw-body/index.js line 262 col 16)
callback.apply(null, args)
5
at done (/var/app/current/node_modules/raw-body/index.js line 251 col 7)
invokeCallback()
6
at IncomingMessage.onEnd (/var/app/current/node_modules/raw-body/index.js line 307 col 7)
done(null, string)
7
at emitNone (events.js line 86 col 13)
8
at IncomingMessage.emit (events.js line 185 col 7)
9
at endReadableNT (_stream_readable.js line 934 col 12)
10
at _combinedTickCallback (internal/process/next_tick.js line 74 col 11)
11
at process._tickDomainCallback (internal/process/next_tick.js line 122 col 9)
```
and [this blogpost](http://blog.matthewdfuller.com/2014/10/nodejs-error-too-many-parameters-at.html) recommended this change.