### PR TITLE
Repl console

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ By default, the environment will be **development**, but you can easily change i
 #### Debugging
 As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (`npm start`), making your debugging easier.
 
+#### REPL console
+We can use a node console with `npm run console`. There your service objects are exposed as _servicename_ + "Service". Let's suppose that we have a service `users` which has a function `getAll`. In your console you can call `usersService.getAll()` and see the result. Note that this works also with functions that return promises! To exit the console use `.exit`.
+
 #### Documentation
 Documentation will be served at `/docs`. Remember using [dictum.js](http://www.github.com/Wolox/dictum.js) package to automatically generate documentation for your endpoints. Check [this link](https://github.com/Wolox/dictum.js#chai) for further details.
 

--- a/console.js
+++ b/console.js
@@ -1,18 +1,38 @@
 const repl = require('repl'),
   fs = require('fs'),
   pjson = require('./package.json'),
-  orm = require('./app/orm'),
-  testFolder = './tests/';
+  orm = require('./app/orm');
+
+const convertFunctionToAsync = f => {
+  return async (...args) => {
+    const result = await f(...args);
+    console.log(JSON.stringify(result, null, 2));
+  };
+};
+
+const convertObjectFunctionsToAsync = serviceMethods => {
+  const asyncServiceMethods = {};
+  Object.keys(serviceMethods).forEach(key => {
+    if (typeof serviceMethods[key] === 'function') {
+      asyncServiceMethods[key] = convertFunctionToAsync(serviceMethods[key]);
+    } else {
+      asyncServiceMethods[key] = serviceMethods[key];
+    }
+  });
+  return asyncServiceMethods;
+};
 
 orm.init().then(() => {
   const replServer = repl.start({
     prompt: `${pjson.name}> `
   });
-
+  replServer.context.orm = orm;
   const servicesPath = './app/services/';
   fs.readdir(servicesPath, (err, files) => {
-    files.forEach((file) => {
-      replServer.context[`${file.split('.')[0]}Service`] = require(`${servicesPath}${file}`);
+    files.forEach(file => {
+      const serviceMethods = require(`${servicesPath}${file}`);
+      const asyncServiceMethods = convertObjectFunctionsToAsync(serviceMethods);
+      replServer.context[`${file.split('.')[0]}Service`] = asyncServiceMethods;
     });
   });
 });

--- a/console.js
+++ b/console.js
@@ -1,0 +1,18 @@
+const repl = require('repl'),
+  fs = require('fs'),
+  pjson = require('./package.json'),
+  orm = require('./app/orm'),
+  testFolder = './tests/';
+
+orm.init().then(() => {
+  const replServer = repl.start({
+    prompt: `${pjson.name}> `
+  });
+
+  const servicesPath = './app/services/';
+  fs.readdir(servicesPath, (err, files) => {
+    files.forEach((file) => {
+      replServer.context[`${file.split('.')[0]}Service`] = require(`${servicesPath}${file}`);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": "2.14.2"
   },
   "scripts": {
+    "console": "node console.js",
     "cover": "NODE_ENV=testing istanbul cover ./node_modules/mocha/bin/_mocha --compilers js:babel-core/register test/app.js",
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",


### PR DESCRIPTION
## Summary
- Adding repl console task. In a terminal: `npm run console`
- Exposing `Orm` and service objects as _servicename_ + "Service"
- Using `Async` and `Await` to make service methods synchronous
- Use `process.env` to print environment vars
- Use `.exit` to exit console

## To review
- Is `Console.log` necessary? Any other way to see the result?
- Do we need to init other thing besides `orm`?  
- Should we change the print format to make it prettier?