### PR TITLE
Upgraded rollbar version for nsp issue and added some error handling.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const express = require('express'),
   bodyParser = require('body-parser'),
-  rollbar = require('rollbar'),
+  Rollbar = require('rollbar'),
   morgan = require('morgan'),
   path = require('path'),
   config = require('./config'),
@@ -53,12 +53,13 @@ const init = () => {
       routes.init(app);
 
       app.use(errors.handle);
-      app.use(
-        rollbar.errorHandler(config.common.rollbar.accessToken, {
-          enabled: !!config.common.rollbar.accessToken,
-          environment: config.environment
-        })
-      );
+
+      const rollbar = new Rollbar({
+        accessToken: config.common.rollbar.accessToken,
+        enabled: !!config.common.rollbar.accessToken,
+        environment: config.common.rollbar.environment || config.environment
+      });
+      app.use(rollbar.errorHandler());
 
       app.listen(port);
       console.log(`Listening on port: ${port}`); // eslint-disable-line

--- a/app/middlewares/errors.js
+++ b/app/middlewares/errors.js
@@ -1,6 +1,12 @@
 const errors = require('../errors');
 
 exports.handle = (error, req, res, next) => {
-  res.status(error.statusCode || 500);
-  res.send({ error: error.message });
+  if (error && error.statusCode) {
+    res.status(error.statusCode);
+  } else {
+    // Unrecognized error, notifying it to rollbar.
+    next(error);
+    res.status(500);
+  }
+  return res.send({ error: error.message });
 };

--- a/config/development.js
+++ b/config/development.js
@@ -19,7 +19,8 @@ exports.config = {
       secret: process.env.NODE_API_SESSION_SECRET
     },
     rollbar: {
-      accessToken: process.env.ROLLBAR_ACCESS_TOKEN
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
+      environment: process.env.ROLLBAR_ENV
     }
   }
 };

--- a/config/production.js
+++ b/config/production.js
@@ -20,7 +20,8 @@ exports.config = {
       secret: process.env.NODE_API_SESSION_SECRET
     },
     rollbar: {
-      accessToken: process.env.ROLLBAR_ACCESS_TOKEN
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
+      environment: process.env.ROLLBAR_ENV
     }
   }
 };

--- a/config/staging.js
+++ b/config/staging.js
@@ -19,7 +19,8 @@ exports.config = {
       secret: process.env.NODE_API_SESSION_SECRET
     },
     rollbar: {
-      accessToken: process.env.ROLLBAR_ACCESS_TOKEN
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
+      environment: process.env.ROLLBAR_ENV
     }
   }
 };

--- a/config/testing.js
+++ b/config/testing.js
@@ -19,7 +19,8 @@ exports.config = {
       secret: process.env.NODE_API_SESSION_SECRET
     },
     rollbar: {
-      accessToken: process.env.ROLLBAR_ACCESS_TOKEN
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
+      environment: process.env.ROLLBAR_ENV
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pg": "^4.4.6",
     "prettier": "^1.7.0",
     "request": "^2.76.0",
-    "rollbar": "^0.6.2",
+    "rollbar": "^2.2.9",
     "sequelize": "^3.30.0",
     "sequelize-cli": "^2.1.0",
     "umzug": "^2.0.1"


### PR DESCRIPTION
## Summary
* Upgraded rollbar package (actually its a different package since the last one was deprecated, for more info, [old rollbar](https://github.com/rollbar/node_rollbar) and [new rollbar](https://github.com/rollbar/rollbar.js)) since the previous version had a dependency with security issues according to nsp.
* Fixed error handler middleware that wasn't sending any error to the rollbar handler.