### PR TITLE
Moved dotenv to the npm start script

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,3 @@
-const dotenv = require('dotenv').config({ path: `${__dirname}/.env` });
-
 const ENVIRONMENT = process.env.NODE_ENV || 'development';
 
 const configFile = `./${ENVIRONMENT}`;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pretest": "npm run lint",
     "prestart": "npm run lint",
     "migrations": "./node_modules/.bin/sequelize --config ./migrations/config.js --migrations-path ./migrations/migrations db:migrate",
-    "start": "./node_modules/.bin/nodemon --inspect app.js",
+    "start": "./node_modules/.bin/nodemon --exec \"node -r dotenv/config\" --inspect app.js",
     "test": "NODE_ENV=testing ./node_modules/mocha/bin/mocha --compilers js:babel-core/register test/app.js && npm run nsp",
     "test-inspect": "NODE_ENV=testing node --inspect --debug-brk ./node_modules/mocha/bin/_mocha --compilers js:babel-core/register test/app.js"
   },


### PR DESCRIPTION
## Summary
We had the following problem: dotenv was listed as a devDedependency but it was required always in the `config/index.js`, so when we deployed the app it would crash. I found the following solutions:
* Move dotenv as a dependency.
* Add an if statement to check if the environment is production then not require the package.
* Move the require of dotenv to the npm start script.

The first one didn't quite hit the mark, I would not like to have an unnecessary package in production, and also the possibility of somebody uploading some `.env` to the production environment and having all the env vars overwritten.
The second one seems a little bit better, but I don't like adding requires inside code logic, but it doesn't seems so tragic to have this one.
The third one seems the most cleaner to me, but it has the risk of somebody removing the package because they don't find the package required anywhere.

I really couldn't choose between the second and third one, so I did the quicker lol. But I am open to implement either one.

Also I changed the expected location of the `.env` to the root of the project.