### PR TITLE
Fixing travis

### DIFF
--- a/config/testing.js
+++ b/config/testing.js
@@ -2,9 +2,6 @@ exports.config = {
   environment: 'testing',
   isTesting: true,
   common: {
-    database: {
-      name: process.env.NODE_API_DB_NAME_TEST
-    },
     session: {
       secret: 'some-super-secret'
     }


### PR DESCRIPTION
## Summary
- stop reassigning database env vars in testing
