### PR TITLE
Replace truncate database script

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -9,23 +9,17 @@ const fs = require('fs'),
 
 chai.use(chaiHttp);
 
-const getTablesQuery = `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';`;
+const tables = Object.values(models.sequelize.models);
 
-// THIS WORKS ONLY WITH POSTGRESQL
+const truncateTable = model =>
+  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
+
+const truncateDatabase = () => Promise.all(tables.map(truncateTable));
+
 beforeEach('drop tables, re-create them and populate sample data', done => {
-  models.sequelize.query(getTablesQuery).then(tables => {
-    const tableExpression = tables
-      .map(table => {
-        return `"public"."${table[0]}"`;
-      })
-      .join(', ');
-    return models.sequelize
-      .query(`TRUNCATE TABLE ${tableExpression} RESTART IDENTITY`)
-      .then(() => {
-        return dataCreation.execute();
-      })
-      .then(() => done());
-  });
+  truncateDatabase()
+    .then(() => dataCreation.execute())
+    .then(() => done());
 });
 
 // including all test files


### PR DESCRIPTION
## Summary

This PR replace functionality in charge of truncate database before each test case. 

Advantages:

- Last implementation only works with Postgres databases. On the contrary, this implementation works with any database that supports TRUNCATE.

- It is more idiomatic and prescinde of using raw queries.

## Known Issues

None

## Trello Card

None