### PR TITLE
upgraded sequelize default version to 5.10.1

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -1,6 +1,6 @@
 exports.NODE_DEFAULT_VERSION = '10.14.1';
 exports.NPM_DEFAULT_VERSION = '6.4.1';
-exports.SEQUELIZE_DEFAULT_VERSION = '4.34.0';
+exports.SEQUELIZE_DEFAULT_VERSION = '5.10.1';
 exports.SEQUELIZE_DEFAULT_DIALECT = 'postgres';
 exports.SEQUELIZE_DIALECTS = ['mysql', 'sqlite', 'postgres', 'mssql'];
 exports.DEPLOY_STRATEGIES = ['aws', 'heroku'];


### PR DESCRIPTION
# Summary

- Upgraded default sequelize version to 5.10.1.