### PR TITLE
Added "start-dev" script.

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -67,7 +67,7 @@ Then, set in `.env` some variables:
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run `npm start` in the root path of yout project. To start your app in development mode (nodemon) run `npm run start-dev`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run `npm start` in the root path of your project. To start your app in development mode (nodemon) run `npm run start-dev`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -124,7 +124,7 @@ Also, it takes values predefined in the `type` field (Sequelize Datatype) and th
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using `npm run start-dev`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using `npm run start-dev`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -64,9 +64,10 @@ Then, set in `.env` some variables:
 - PACKAGE_VERSION=X-Package-Version
 - NODE_VERSION=X-Node-Version
 <%}%>
+
 #### Starting your app
 
-Now, to start your app run `npm start` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run `npm start` in the root path of yout project. To start your app in development mode (nodemon) run `npm run start-dev`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -116,14 +116,15 @@ Once you have all the above done you can run your tests with the following comma
 <% if(orm.sequelize && testing === 'jest-supertest') {%>
 #### Factory Girl
 
-To simplify your tests, you can call the `factoryByModel('nameOfModel')` function in `factory_by_models.js` on your code, then, `factory.build('nameOfModel')` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its `dataValues` field.
+To simplify your tests, you can call the `factoryByModel('nameOfModel')` function in `factory_by_models.js` on your code, then, `factory.build('nameOfModel')` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its `dataValues` field.
 Remember that you have to create a model before, and the `nameOfModel` will be the one you will have on the database (which is the first parameter on `sequelize.define()`).
 
 Also, it takes values predefined in the `type` field (Sequelize Datatype) and the validations you have in your MODEL (`validate` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 <%}%>
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (`npm start`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using `npm run start-dev`, making your debugging easier.
 
 #### REPL console
 

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -22,10 +22,11 @@
     "precommit": "npm run lint-diff",
     "outdated": "npm outdated --depth 0",
     "pretest": "npm run lint",
-    "prestart": "npm run lint",<% if(orm.sequelize) {%>
+    "start-dev": "nodemon --inspect server.js",
+    "prestart-dev": "npm run lint",<% if(orm.sequelize) {%>
     "migrations": "sequelize db:migrate",<% if(!inTraining) {%>
     "migrations-test": "NODE_ENV=testing sequelize db:migrate",<%}}%>
-    "start": "nodemon --inspect server.js"
+    "start": "node server.js"
   },
   "cacheDirectories": [
     "node_modules"

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -577,8 +577,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creat
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -1290,8 +1291,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creat
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -1951,8 +1953,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and all optionals create
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -2615,8 +2618,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and non optionals create
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -3605,10 +3609,11 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -3709,10 +3714,11 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -4781,10 +4787,11 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -4889,10 +4896,11 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -5917,10 +5925,11 @@ exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and 
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -6000,10 +6009,11 @@ exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and 
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -7002,10 +7012,11 @@ exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -7081,10 +7092,11 @@ exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -210,7 +210,7 @@ Run \`npm install\` or \`yarn\` from rootpath of the project.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -260,7 +260,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -933,7 +933,7 @@ Run \`npm install\` or \`yarn\` from rootpath of the project.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -983,7 +983,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -1590,7 +1590,7 @@ Run \`npm install\` or \`yarn\` from rootpath of the project.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1640,7 +1640,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -2264,7 +2264,7 @@ Run \`npm install\` or \`yarn\` from rootpath of the project.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2314,7 +2314,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -3003,7 +3003,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -3060,7 +3060,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -3165,7 +3165,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -3222,7 +3222,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -4178,7 +4178,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -4235,7 +4235,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -4340,7 +4340,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -4397,7 +4397,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -5334,7 +5334,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -5384,7 +5384,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -5489,7 +5489,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -5539,7 +5539,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -6432,7 +6432,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -6482,7 +6482,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -6587,7 +6587,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -6637,7 +6637,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -207,9 +207,10 @@ Nvm approach is preferred.
 
 Run \`npm install\` or \`yarn\` from rootpath of the project.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -928,9 +929,10 @@ Nvm approach is preferred.
 
 Run \`npm install\` or \`yarn\` from rootpath of the project.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1583,9 +1585,10 @@ Nvm approach is preferred.
 
 Run \`npm install\` or \`yarn\` from rootpath of the project.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2255,9 +2258,10 @@ Nvm approach is preferred.
 
 Run \`npm install\` or \`yarn\` from rootpath of the project.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2992,9 +2996,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -3152,9 +3157,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -4163,9 +4169,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -4323,9 +4330,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -5315,9 +5323,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -5468,9 +5477,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -6409,9 +6419,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -6562,9 +6573,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -257,9 +257,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Jest](https://jestjs.io/docs/en/getting-started).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -979,9 +980,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Jest](https://jestjs.io/docs/en/getting-started).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -1635,9 +1637,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Jest](https://jestjs.io/docs/en/getting-started).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -2308,9 +2311,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Jest](https://jestjs.io/docs/en/getting-started).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -3048,14 +3052,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -3209,14 +3214,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -4221,14 +4227,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -4382,14 +4389,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -5373,9 +5381,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -5527,9 +5536,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -6469,9 +6479,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -6623,9 +6634,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -39,9 +39,10 @@ Then, set in \`.env\` some variables:
 - PACKAGE_VERSION=X-Package-Version
 - NODE_VERSION=X-Node-Version
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -89,9 +89,10 @@ before in [Database configuration](#database-configuration). Also you need to ru
 testing database each time you have new ones, you can do this by running the command \`npm run migrations-test\`.
 Once you have all the above done you can run your tests with the following command: \`npm test\`. For more information refeer to the documentation of [Jest](https://jestjs.io/docs/en/getting-started).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -42,7 +42,7 @@ Then, set in \`.env\` some variables:
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -92,7 +92,7 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -221,8 +221,9 @@ exports[`Mongoose project  creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"

--- a/test/__snapshots__/optionals.spec.js.snap
+++ b/test/__snapshots__/optionals.spec.js.snap
@@ -69,8 +69,9 @@ exports[`Project with cors creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -169,8 +170,9 @@ exports[`Project with coveralls creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -314,8 +316,9 @@ exports[`Project with rollbar creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -121,14 +121,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -514,14 +515,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -932,14 +934,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -1325,14 +1328,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -1743,14 +1747,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -2136,14 +2141,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -2554,14 +2560,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 
@@ -2947,14 +2954,15 @@ Once you have all the above done you can run your tests with the following comma
 
 #### Factory Girl
 
-To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the vaules created will be on its \`dataValues\` field.
+To simplify your tests, you can call the \`factoryByModel('nameOfModel')\` function in \`factory_by_models.js\` on your code, then, \`factory.build('nameOfModel')\` and it will define a json object with the attributes form the model you've passed as parameter taking random values. If you want to acceed to the object created, the values created will be on its \`dataValues\` field.
 Remember that you have to create a model before, and the \`nameOfModel\` will be the one you will have on the database (which is the first parameter on \`sequelize.define()\`).
 
 Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and the validations you have in your MODEL (\`validate\` field),so if you want to validate those values on middlewares or somewhere else, factoryByModel won't take this in count. We strongly recommend to check if those validations cover the cases you expect, and if it doesn't, you can add your own code on this file (or just define a new factory).
 
+
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (\`npm start\`), making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
 
 #### REPL console
 

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -72,7 +72,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -129,7 +129,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -466,7 +466,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -523,7 +523,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -885,7 +885,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -942,7 +942,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -1279,7 +1279,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1336,7 +1336,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -1698,7 +1698,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1755,7 +1755,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -2092,7 +2092,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2149,7 +2149,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -2511,7 +2511,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2568,7 +2568,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 
@@ -2905,7 +2905,7 @@ To run them, execute \`npm run migrations\`.
 
 #### Starting your app
 
-Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of your project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2962,7 +2962,7 @@ Also, it takes values predefined in the \`type\` field (Sequelize Datatype) and 
 
 #### Debugging
 
-As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. If you download a node inspection manager for chrome (for example: <https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en-US>) Chrome DevTools will get started automatically when running your app using \`npm run start-dev\`, making your debugging easier.
+As we know, a NodeJS application is not something easy to debug and because of that we've added the \`--inspect\` flag to make it simpler. You can download a node inspection manager for Chrome, so Chrome DevTools will automatically start when you run your app using \`npm run start-dev\`, making your debugging easier. You can read more about the different inspector clients here: <https://nodejs.org/de/docs/guides/debugging-getting-started/#inspector-clients>
 
 #### REPL console
 

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -69,9 +69,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -461,9 +462,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -878,9 +880,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1270,9 +1273,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -1687,9 +1691,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2079,9 +2084,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2496,9 +2502,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 
@@ -2888,9 +2895,10 @@ To create a migration, run \`./node_modules/.bin/sequelize migration:create --na
 
 To run them, execute \`npm run migrations\`.
 
+
 #### Starting your app
 
-Now, to start your app run \`npm start\` in the rootpath of the project. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
+Now, we have two ways to start an app. To start your app in production mode run \`npm start\` in the root path of yout project. To start your app in development mode (nodemon) run \`npm run start-dev\`. Then access your app at **localhost:port**. The port is logged in the console where you ran the start script.
 
 ## Development
 

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -278,10 +278,11 @@ exports[`Sequelize project (mssql) along with Jenkins creates expected package.j
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -669,10 +670,11 @@ exports[`Sequelize project (mssql) creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -1085,10 +1087,11 @@ exports[`Sequelize project (mysql) along with Jenkins creates expected package.j
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -1476,10 +1479,11 @@ exports[`Sequelize project (mysql) creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -1892,10 +1896,11 @@ exports[`Sequelize project (postgres) along with Jenkins creates expected packag
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -2283,10 +2288,11 @@ exports[`Sequelize project (postgres) creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -2699,10 +2705,11 @@ exports[`Sequelize project (sqlite) along with Jenkins creates expected package.
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -3090,10 +3097,11 @@ exports[`Sequelize project (sqlite) creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
     \\"migrations\\": \\"sequelize db:migrate\\",
     \\"migrations-test\\": \\"NODE_ENV=testing sequelize db:migrate\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"

--- a/test/__snapshots__/testing.spec.js.snap
+++ b/test/__snapshots__/testing.spec.js.snap
@@ -21,8 +21,9 @@ exports[`jest-supertest project creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"
@@ -141,8 +142,9 @@ exports[`mocha-chai project creates expected package.json 1`] = `
     \\"precommit\\": \\"npm run lint-diff\\",
     \\"outdated\\": \\"npm outdated --depth 0\\",
     \\"pretest\\": \\"npm run lint\\",
-    \\"prestart\\": \\"npm run lint\\",
-    \\"start\\": \\"nodemon --inspect server.js\\"
+    \\"start-dev\\": \\"nodemon --inspect server.js\\",
+    \\"prestart-dev\\": \\"npm run lint\\",
+    \\"start\\": \\"node server.js\\"
   },
   \\"cacheDirectories\\": [
     \\"node_modules\\"


### PR DESCRIPTION
## Summary

Now "npm run start-dev" starts the process with nodemon, "npm start" does "node server.js". The prestart validation now is called prestart-dev.  
It is not really necessary to leave "node start" in the scripts section of package-lock.js, since the default behavior of nmp start when no start script is provided is to run "node server.js", but it was left there to make it more explicit.
Issue #67 (https://github.com/Wolox/express-js-bootstrap/issues/67) solved.


## Known Issues

No known issues.

## Trello Card

https://trello.com/c/pmjLN52y
