### PR TITLE
Remove app.spec.js from Jest default configuration

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -97,6 +97,16 @@ exports.files = [
     condition: answers => answers.orm.sequelize && answers.testing === 'jest-supertest'
   },
   {
+    directory: 'test',
+    name: 'setup.js',
+    condition: answers => answers.orm.sequelize && answers.testing === 'jest-supertest'
+  },
+  {
+    directory: 'test',
+    name: 'app.spec.ejs',
+    condition: answers => answers.testing === 'mocha-chai'
+  },
+  {
     name: 'README.md'
   },
   {
@@ -149,10 +159,6 @@ exports.files = [
   },
   {
     name: '.eslintignore'
-  },
-  {
-    directory: 'test',
-    name: 'app.spec.ejs'
   },
   {
     directory: 'config',

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -11,9 +11,9 @@
     "cover": "NODE_ENV=testing istanbul cover ./node_modules/mocha/bin/_mocha  test/app.spec.js",
     "test": "NODE_ENV=testing ./node_modules/mocha/bin/_mocha --timeout 6000 --exit test/app.spec.js",
     "test-inspect": "NODE_ENV=testing node --inspect --debug-brk ./node_modules/mocha/bin/_mocha test/app.spec.js",<%} if(testing === 'jest-supertest') {%>
-    "cover": "NODE_ENV=testing jest --coverage --runInBand --forceExit test/app",
-    "test": "NODE_ENV=testing jest test/app --runInBand --forceExit",
-    "test-inspect": "NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js",<%} if(optionalsFeatures.coveralls) {%>
+    "cover": "npm run test --coverage",
+    "test": "NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles",
+    "test-inspect": "NODE_ENV=testing node --inspect --debug-brk jest",<%} if(optionalsFeatures.coveralls) {%>
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",<%}%>
     "eslint-check": "eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check",
     "lint": "eslint \"**/*.js\" --ignore-pattern ./.eslintrc.js",
@@ -60,6 +60,9 @@
       "!**/config/**",
       "!**/scripts/**"
     ],
+    "setupFilesAfterEnv": {
+      ["<rootDir>/test/setup.js"]
+    },
     "testEnvironment": "node",
     "transform": {
       "^.+\\.js$": "babel-jest"

--- a/generators/app/templates/test/app.spec.ejs
+++ b/generators/app/templates/test/app.spec.ejs
@@ -2,12 +2,11 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');<% if(testing === 'mocha-chai') {%>
+const path = require('path');
 const chaiHttp = require('chai-http');
 const chai = require('chai');<%} if(orm.sequelize) {%>
 const models = require('../app/models');<%}%>
-<% if(testing === 'mocha-chai') {%>
-chai.use(chaiHttp);<%}%>
+chai.use(chaiHttp);
 <% if(orm.sequelize) {%>
 const tables = Object.values(models.sequelize.models);
 

--- a/generators/app/templates/test/setup.js
+++ b/generators/app/templates/test/setup.js
@@ -1,0 +1,12 @@
+const models = require('../app/models');
+
+const tables = Object.values(models.sequelize.models);
+
+const truncateTable = model =>
+  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
+
+const truncateDatabase = () => Promise.all(tables.map(truncateTable));
+
+global.beforeEach(async () => {
+  await truncateDatabase();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3895,10 +3895,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -4302,7 +4305,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4323,12 +4327,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4343,17 +4349,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4470,7 +4479,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4482,6 +4492,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4496,6 +4507,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4503,12 +4515,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4527,6 +4541,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4607,7 +4622,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4619,6 +4635,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4704,7 +4721,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4740,6 +4758,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4759,6 +4778,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4802,12 +4822,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generators"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --silent",
     "eslint-check": "eslint --print-config .eslintrc.js",
     "lint": "eslint --ignore-pattern 'generators/app/templates/' \"**/*.js\" ",
     "lint-diff": "git diff --name-only --cached --relative | grep \\\\.js$ | xargs eslint",

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -566,9 +566,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creat
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"coveralls\\": \\"npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
@@ -613,6 +613,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creat
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -696,28 +699,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creates expected .eslintignore 1`] = `
@@ -1280,9 +1261,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creat
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -1326,6 +1307,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creat
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1399,28 +1383,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with AWS, Docker, Jest, Travis and all optionals creates expected .eslintignore 1`] = `
@@ -1940,9 +1902,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and all optionals create
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"coveralls\\": \\"npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
@@ -1987,6 +1949,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and all optionals create
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2070,28 +2035,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with AWS, Docker, Jest, Travis and all optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with AWS, Docker, Jest, Travis and non optionals creates expected .eslintignore 1`] = `
@@ -2605,9 +2548,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and non optionals create
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -2651,6 +2594,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and non optionals create
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2724,28 +2670,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with AWS, Docker, Jest, Travis and non optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and non optionals creates expected .eslintignore 1`] = `
@@ -3595,9 +3519,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -3643,6 +3567,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -3699,9 +3626,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -3747,6 +3674,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -3845,76 +3775,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and non optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
-`;
-
-exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and non optionals creates expected test/app.spec.js 2`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins and all optionals creates expected .eslintignore 1`] = `
@@ -4770,9 +4630,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"coveralls\\": \\"npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
@@ -4819,6 +4679,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -4878,9 +4741,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"coveralls\\": \\"npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
@@ -4927,6 +4790,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -5042,76 +4908,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins and all optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
-`;
-
-exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins and all optionals creates expected test/app.spec.js 2`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and all optionals creates expected .eslintignore 1`] = `
@@ -6130,82 +5926,6 @@ Promise.resolve()
   .catch(logger.error);"
 `;
 
-exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and all optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const chaiHttp = require('chai-http');
-const chai = require('chai');
-const models = require('../app/models');
-
-chai.use(chaiHttp);
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
-`;
-
-exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and all optionals creates expected test/app.spec.js 2`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const chaiHttp = require('chai-http');
-const chai = require('chai');
-const models = require('../app/models');
-
-chai.use(chaiHttp);
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
-`;
-
 exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and non optionals creates expected .eslintignore 1`] = `
 "app/dist
 "
@@ -7192,80 +6912,4 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and non optionals creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const chaiHttp = require('chai-http');
-const chai = require('chai');
-const models = require('../app/models');
-
-chai.use(chaiHttp);
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
-`;
-
-exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and non optionals creates expected test/app.spec.js 2`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const chaiHttp = require('chai-http');
-const chai = require('chai');
-const models = require('../app/models');
-
-chai.use(chaiHttp);
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -211,9 +211,9 @@ exports[`Mongoose project  creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -257,6 +257,9 @@ exports[`Mongoose project  creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -317,26 +320,4 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Mongoose project  creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;

--- a/test/__snapshots__/optionals.spec.js.snap
+++ b/test/__snapshots__/optionals.spec.js.snap
@@ -59,9 +59,9 @@ exports[`Project with cors creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -105,6 +105,9 @@ exports[`Project with cors creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -158,9 +161,9 @@ exports[`Project with coveralls creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"coveralls\\": \\"npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
@@ -205,6 +208,9 @@ exports[`Project with coveralls creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -304,9 +310,9 @@ exports[`Project with rollbar creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -350,6 +356,9 @@ exports[`Project with rollbar creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -268,9 +268,9 @@ exports[`Sequelize project (mssql) along with Jenkins creates expected package.j
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -316,6 +316,9 @@ exports[`Sequelize project (mssql) along with Jenkins creates expected package.j
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -379,41 +382,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (mssql) along with Jenkins creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (mssql) creates expected README.md 1`] = `
@@ -659,9 +627,9 @@ exports[`Sequelize project (mssql) creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -707,6 +675,9 @@ exports[`Sequelize project (mssql) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -770,41 +741,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (mssql) creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (mysql) along with Jenkins creates expected .woloxci/config.yml 1`] = `
@@ -1075,9 +1011,9 @@ exports[`Sequelize project (mysql) along with Jenkins creates expected package.j
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -1123,6 +1059,9 @@ exports[`Sequelize project (mysql) along with Jenkins creates expected package.j
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1186,41 +1125,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (mysql) along with Jenkins creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (mysql) creates expected README.md 1`] = `
@@ -1466,9 +1370,9 @@ exports[`Sequelize project (mysql) creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -1514,6 +1418,9 @@ exports[`Sequelize project (mysql) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1577,41 +1484,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (mysql) creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (postgres) along with Jenkins creates expected .woloxci/config.yml 1`] = `
@@ -1882,9 +1754,9 @@ exports[`Sequelize project (postgres) along with Jenkins creates expected packag
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -1930,6 +1802,9 @@ exports[`Sequelize project (postgres) along with Jenkins creates expected packag
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1993,41 +1868,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (postgres) along with Jenkins creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (postgres) creates expected README.md 1`] = `
@@ -2273,9 +2113,9 @@ exports[`Sequelize project (postgres) creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -2321,6 +2161,9 @@ exports[`Sequelize project (postgres) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2384,41 +2227,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (postgres) creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (sqlite) along with Jenkins creates expected .woloxci/config.yml 1`] = `
@@ -2689,9 +2497,9 @@ exports[`Sequelize project (sqlite) along with Jenkins creates expected package.
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -2737,6 +2545,9 @@ exports[`Sequelize project (sqlite) along with Jenkins creates expected package.
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2800,41 +2611,6 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (sqlite) along with Jenkins creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;
 
 exports[`Sequelize project (sqlite) creates expected README.md 1`] = `
@@ -3080,9 +2856,9 @@ exports[`Sequelize project (sqlite) creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -3128,6 +2904,9 @@ exports[`Sequelize project (sqlite) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -3191,39 +2970,4 @@ Promise.resolve()
     logger.info(\`Listening on port: \${port}\`);
   })
   .catch(logger.error);"
-`;
-
-exports[`Sequelize project (sqlite) creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const models = require('../app/models');
-
-
-const tables = Object.values(models.sequelize.models);
-
-const truncateTable = model =>
-  model.destroy({ truncate: true, cascade: true, force: true, restartIdentity: true });
-
-const truncateDatabase = () => Promise.all(tables.map(truncateTable));
-
-beforeEach(done => {
-  truncateDatabase()
-    .then(() => done());
-});
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
-"
 `;

--- a/test/__snapshots__/testing.spec.js.snap
+++ b/test/__snapshots__/testing.spec.js.snap
@@ -11,9 +11,9 @@ exports[`jest-supertest project creates expected package.json 1`] = `
   },
   \\"scripts\\": {
     \\"console\\": \\"node console.js\\",
-    \\"cover\\": \\"NODE_ENV=testing jest --coverage --runInBand --forceExit test/app\\",
-    \\"test\\": \\"NODE_ENV=testing jest test/app --runInBand --forceExit\\",
-    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js\\",
+    \\"cover\\": \\"npm run test --coverage\\",
+    \\"test\\": \\"NODE_ENV=testing jest --runInBand --forceExit --detectOpenHandles\\",
+    \\"test-inspect\\": \\"NODE_ENV=testing node --inspect --debug-brk jest\\",
     \\"eslint-check\\": \\"eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check\\",
     \\"lint\\": \\"eslint \\\\\\"**/*.js\\\\\\" --ignore-pattern ./.eslintrc.js\\",
     \\"lint-diff\\": \\"git diff --name-only --cached --relative | grep \\\\\\\\\\\\\\\\.js$ | xargs eslint\\",
@@ -57,6 +57,9 @@ exports[`jest-supertest project creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
+    \\"setupFilesAfterEnv\\": {
+      [\\"<rootDir>/test/setup.js\\"]
+    },
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -95,28 +98,6 @@ exports[`jest-supertest project creates expected package.json 1`] = `
     \\"eslint-config-wolox-node\\": \\"^2.0.0\\"
   }
 }
-"
-`;
-
-exports[`jest-supertest project creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
 "
 `;
 
@@ -191,30 +172,5 @@ exports[`mocha-chai project creates expected package.json 1`] = `
     \\"eslint-config-wolox-node\\": \\"^2.0.0\\"
   }
 }
-"
-`;
-
-exports[`mocha-chai project creates expected test/app.spec.js 1`] = `
-"/* eslint-disable global-require */
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const chaiHttp = require('chai-http');
-const chai = require('chai');
-
-chai.use(chaiHttp);
-
-// including all test files
-const normalizedPath = path.join(__dirname, '.');
-
-const requireAllTestFiles = pathToSearch => {
-  fs.readdirSync(pathToSearch).forEach(file => {
-    if (fs.lstatSync(\`\${pathToSearch}/\${file}\`).isDirectory()) requireAllTestFiles(\`\${pathToSearch}/\${file}\`);
-    else require(\`\${pathToSearch}/\${file}\`);
-  });
-};
-
-requireAllTestFiles(normalizedPath);
 "
 `;

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -6,25 +6,11 @@ exports.sequelizeFiles = [
   'app/models/index.js'
 ];
 
-exports.sequelizeTemplateFiles = [
-  'package.json',
-  'README.md',
-  'console.js',
-  'server.js',
-  'test/app.spec.js',
-  'config/db.js'
-];
+exports.sequelizeTemplateFiles = ['package.json', 'README.md', 'console.js', 'server.js', 'config/db.js'];
 
-exports.mongooseTemplateFiles = [
-  'package.json',
-  'README.md',
-  'console.js',
-  'server.js',
-  'test/app.spec.js',
-  'config/db.js'
-];
+exports.mongooseTemplateFiles = ['package.json', 'README.md', 'console.js', 'server.js', 'config/db.js'];
 
-exports.testingFiles = ['package.json', 'test/app.spec.js'];
+exports.testingFiles = ['package.json'];
 
 exports.jenkinsFiles = ['Jenkinsfile', '.woloxci/config.yml', '.woloxci/Dockerfile'];
 
@@ -46,7 +32,6 @@ exports.basicFiles = [
   '.gitignore',
   '.eslintrc.js',
   '.eslintignore',
-  'test/app.spec.js',
   'config/development.js',
   'config/production.js',
   'config/testing.js',


### PR DESCRIPTION
## Summary

- Remove `app.spec.js` only for Jest.

Jest detects test files using a file naming convention. This allows us to run specific tests, make easier debugging and more.

## Known Issues

N/A

## Trello Card

N/A