### PR TITLE
Hotfix in package.json for Jest config

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -60,9 +60,9 @@
       "!**/config/**",
       "!**/scripts/**"
     ],
-    "setupFilesAfterEnv": {
-      ["<rootDir>/test/setup.js"]
-    },
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup.js"
+    ],
     "testEnvironment": "node",
     "transform": {
       "^.+\\.js$": "babel-jest"

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -613,9 +613,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creat
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1307,9 +1307,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creat
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1949,9 +1949,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and all optionals create
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2594,9 +2594,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and non optionals create
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -3574,9 +3574,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -3681,9 +3681,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -4693,9 +4693,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -4804,9 +4804,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"

--- a/test/__snapshots__/mongoose.spec.js.snap
+++ b/test/__snapshots__/mongoose.spec.js.snap
@@ -257,9 +257,9 @@ exports[`Mongoose project  creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"

--- a/test/__snapshots__/optionals.spec.js.snap
+++ b/test/__snapshots__/optionals.spec.js.snap
@@ -105,9 +105,9 @@ exports[`Project with cors creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -208,9 +208,9 @@ exports[`Project with coveralls creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -356,9 +356,9 @@ exports[`Project with rollbar creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"

--- a/test/__snapshots__/sequelize.spec.js.snap
+++ b/test/__snapshots__/sequelize.spec.js.snap
@@ -321,9 +321,9 @@ exports[`Sequelize project (mssql) along with Jenkins creates expected package.j
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -685,9 +685,9 @@ exports[`Sequelize project (mssql) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1074,9 +1074,9 @@ exports[`Sequelize project (mysql) along with Jenkins creates expected package.j
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1438,9 +1438,9 @@ exports[`Sequelize project (mysql) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -1827,9 +1827,9 @@ exports[`Sequelize project (postgres) along with Jenkins creates expected packag
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2191,9 +2191,9 @@ exports[`Sequelize project (postgres) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2580,9 +2580,9 @@ exports[`Sequelize project (sqlite) along with Jenkins creates expected package.
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"
@@ -2944,9 +2944,9 @@ exports[`Sequelize project (sqlite) creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"

--- a/test/__snapshots__/testing.spec.js.snap
+++ b/test/__snapshots__/testing.spec.js.snap
@@ -57,9 +57,9 @@ exports[`jest-supertest project creates expected package.json 1`] = `
       \\"!**/config/**\\",
       \\"!**/scripts/**\\"
     ],
-    \\"setupFilesAfterEnv\\": {
-      [\\"<rootDir>/test/setup.js\\"]
-    },
+    \\"setupFilesAfterEnv\\": [
+      \\"<rootDir>/test/setup.js\\"
+    ],
     \\"testEnvironment\\": \\"node\\",
     \\"transform\\": {
       \\"^.+\\\\\\\\.js$\\": \\"babel-jest\\"


### PR DESCRIPTION
## Summary

- Fix typo in package.json for Jest configuration.

Actual: 
```
   "setupFilesAfterEnv": {
      ["<rootDir>/test/setup.js"]
   },
```
Expected: 
```
   "setupFilesAfterEnv": [
      "<rootDir>/test/setup.js"
    ],
```
## Known Issues
N/A