### PR TITLE
Changed config to not require dotenv on production

### DIFF
--- a/generators/app/templates/config/index.ejs
+++ b/generators/app/templates/config/index.ejs
@@ -1,7 +1,7 @@
 const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = `./${ENVIRONMENT}`;
 

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -441,9 +441,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creat
 
 exports[`Example project with AWS, Docker, Jest, Jenkins and all optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -1144,9 +1144,9 @@ exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creat
 
 exports[`Example project with AWS, Docker, Jest, Jenkins and non optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -1785,9 +1785,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and all optionals create
 
 exports[`Example project with AWS, Docker, Jest, Travis and all optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -2439,9 +2439,9 @@ exports[`Example project with AWS, Docker, Jest, Travis and non optionals create
 
 exports[`Example project with AWS, Docker, Jest, Travis and non optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -3373,9 +3373,9 @@ exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and 
 
 exports[`Example project with Sequelize (MySQL), AWS, Docker, Jest, Jenkins and non optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -4494,9 +4494,9 @@ exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins a
 
 exports[`Example project with Sequelize (Postgres), AWS, Docker, Jest, Jenkins and all optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -5576,9 +5576,9 @@ exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and 
 
 exports[`Example project with Sequelize (mssql), AWS, Docker, Mocha, Travis and all optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 
@@ -6600,9 +6600,9 @@ exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and
 
 exports[`Example project with Sequelize (sqlite), AWS, Docker, Mocha, Travis and non optionals creates expected config/index.js 1`] = `
 "const ENVIRONMENT = process.env.NODE_ENV || 'development';
-const dotenv = require('dotenv');
 
-if (ENVIRONMENT !== 'production') dotenv.config();
+// eslint-disable-next-line global-require
+if (ENVIRONMENT !== 'production') require('dotenv').config();
 
 const configFile = \`./\${ENVIRONMENT}\`;
 


### PR DESCRIPTION
## Summary
- Now `dotenv` is not required when `NODE_ENV` is production. This is because having `dotenv` be required globally causes deploys to crash.