### PR TITLE
Fix config assignObject modifies 'target'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Changelogs added.
 * Add start-dev option and change behaviour of npm start (#121)
+* Replace 'assignObject' method in configuration for an immutable alternative (#153).

--- a/generators/app/templates/config/index.ejs
+++ b/generators/app/templates/config/index.ejs
@@ -8,16 +8,17 @@ const configFile = `./${ENVIRONMENT}`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -52,4 +53,4 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);

--- a/test/__snapshots__/general.spec.js.snap
+++ b/test/__snapshots__/general.spec.js.snap
@@ -450,16 +450,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -494,7 +495,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -1153,16 +1154,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -1193,7 +1195,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -1794,16 +1796,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -1838,7 +1841,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -2448,16 +2451,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -2488,7 +2492,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -3382,16 +3386,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -3422,7 +3427,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -4503,16 +4508,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -4547,7 +4553,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -5585,16 +5591,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -5629,7 +5636,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 
@@ -6609,16 +6616,17 @@ const configFile = \`./\${ENVIRONMENT}\`;
 const isObject = variable => variable instanceof Object;
 
 /*
- * Deep copy of source object into tarjet object.
- * It does not overwrite properties.
-*/
-const assignObject = (target, source) => {
-  if (target && isObject(target) && source && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === undefined) {
-        target[key] = source[key];
-      } else assignObject(target[key], source[key]);
-    });
+ * Deep immutable copy of source object into tarjet object and returns a new object.
+ */
+const deepMerge = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return Object.keys(source).reduce(
+      (output, key) => ({
+        ...output,
+        [key]: isObject(source[key]) && key in target ? deepMerge(target[key], source[key]) : source[key]
+      }),
+      { ...target }
+    );
   }
   return target;
 };
@@ -6649,7 +6657,7 @@ const config = {
 };
 
 const customConfig = require(configFile).config;
-module.exports = assignObject(customConfig, config);
+module.exports = deepMerge(config, customConfig);
 "
 `;
 


### PR DESCRIPTION
## Summary

Replace `assignObject` function in configuration file for pure alternative that doesn't modify target object.

## Known Issues

N/A

## Trello Card 

https://trello.com/c/7vIV2aQ7/128-modificar-assignobject-en-la-config-para-que-sea-una-funci%C3%B3n-pura