### PR TITLE
chore: use jest as default option for testing

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -12,7 +12,7 @@ exports.MONGOOSE_DIALECTS = ['mongoDB'];
 exports.DEPLOY_STRATEGIES = ['aws', 'heroku'];
 exports.OPTIONALS_FEATURES = ['coveralls', 'rollbar', 'cors', 'helmet'];
 exports.CI_OPTIONS = ['jenkins', 'travis'];
-exports.TESTING_OPTIONS = ['mocha-chai', 'jest-supertest'];
+exports.TESTING_OPTIONS = ['jest-supertest', 'mocha-chai'];
 
 exports.TRAINING_CONFIG = {
   projectName: 'WTraining',


### PR DESCRIPTION
## Summary

- Simple change to set Jest as the first option for testing instead of mocha.

## Known Issues

N/A